### PR TITLE
get_file函數取得實體路徑加密檔名錯誤

### DIFF
--- a/class/TadUpFiles.php
+++ b/class/TadUpFiles.php
@@ -1550,6 +1550,7 @@ class TadUpFiles
             } else {
                 $fext = strtolower(pathinfo($original_filename, PATHINFO_EXTENSION));
                 $files[$files_sn]['thumb_pic'] = XOOPS_URL . "/modules/tadtools/images/mimetype/{$fext}.png";
+                $file_name = $this->hash ? $hash_filename : $file_name;
 
                 $files[$files_sn]['link'] = "<a href='{$dl_url}#{$original_filename}' target='{$target}'>{$show_file_name}</a>";
                 $files[$files_sn]['path'] = "{$dl_url}#{$original_filename}";


### PR DESCRIPTION
取得非圖片檔original_file_path及physical_file_path時，加密檔名錯誤